### PR TITLE
Added task_id in the content type

### DIFF
--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -47,7 +47,7 @@ func (pw *fakePageWriter) FlushErrors(msg []string) error    { return nil }
 
 type fakePageWriterFactory struct{}
 
-func (factory *fakePageWriterFactory) makePageWriter(ctx context.Context, format string, uploadURL string, task catalogtask.CatalogTask, taskURL string) (PageWriter, error) {
+func (factory *fakePageWriterFactory) makePageWriter(ctx context.Context, format string, uploadURL string, task catalogtask.CatalogTask, metadata map[string]string) (PageWriter, error) {
 	return &fakePageWriter{}, nil
 }
 

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -47,7 +47,7 @@ func (pw *fakePageWriter) FlushErrors(msg []string) error    { return nil }
 
 type fakePageWriterFactory struct{}
 
-func (factory *fakePageWriterFactory) makePageWriter(ctx context.Context, format string, uploadURL string, task catalogtask.CatalogTask) (PageWriter, error) {
+func (factory *fakePageWriterFactory) makePageWriter(ctx context.Context, format string, uploadURL string, task catalogtask.CatalogTask, taskURL string) (PageWriter, error) {
 	return &fakePageWriter{}, nil
 }
 

--- a/internal/tarwriter/tarwriter.go
+++ b/internal/tarwriter/tarwriter.go
@@ -19,9 +19,10 @@ type TarWriter struct {
 	uploadUrl string
 	ctx       context.Context
 	glog      logger.Logger
+	metadata  map[string]string
 }
 
-func MakeTarWriter(ctx context.Context, task catalogtask.CatalogTask, uploadUrl string) (*TarWriter, error) {
+func MakeTarWriter(ctx context.Context, task catalogtask.CatalogTask, uploadUrl string, metadata map[string]string) (*TarWriter, error) {
 	glog := logger.GetLogger(ctx)
 	t := TarWriter{}
 	dir, err := ioutil.TempDir("", "catalog_client")
@@ -34,6 +35,7 @@ func MakeTarWriter(ctx context.Context, task catalogtask.CatalogTask, uploadUrl 
 	t.uploadUrl = uploadUrl
 	t.ctx = ctx
 	t.glog = glog
+	t.metadata = metadata
 	return &t, nil
 }
 
@@ -62,7 +64,7 @@ func (tw *TarWriter) Flush() error {
 		tw.glog.Errorf("Error compressing directory %s %v", tw.dir, err)
 	}
 
-	b, uploadErr := upload.Upload(tw.uploadUrl, fname, "application/vnd.redhat.topological-inventory.filename+tgz")
+	b, uploadErr := upload.Upload(tw.uploadUrl, fname, "application/vnd.redhat.topological-inventory.filename+tgz", tw.metadata)
 	os.RemoveAll(tw.dir)
 	os.RemoveAll(tmpdir)
 	if uploadErr != nil {

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -36,8 +36,10 @@ func TestUpload(t *testing.T) {
 	f.Write(data)
 	f.Close()
 	defer os.Remove("testuploaddata.file")
-
-	body, err := Upload(ts.URL+"/upload", "testuploaddata.file", "")
+	metadata := map[string]string{
+		"task_url": "https://www.example.com/12345678",
+	}
+	body, err := Upload(ts.URL+"/upload", "testuploaddata.file", "", metadata)
 	if err != nil {
 		t.Error("ERROR from Upload:", err)
 	}


### PR DESCRIPTION
This helps us to co-relate which taskid this payload belongs to.
We have been working with ingress team to provide us a way to upload
metadata along with the file, that feature is still in discussion so
in the meantime the work around they suggested is to  store the task_id in a portion of the content
type

The content type is currently
"application/vnd.redhat.topological-inventory.filename+tgz"

The filename portion is the category
We are changing this to
"application/vnd.redhat.topological-inventory.b761ca40-e53e-4a5f-97cf-7453bdbdca93+tgz"

In the JSON message from the Ingress Service this shows up as Category

b'{"account":"6089719","category":"b761ca40-e53e-4a5f-97cf-7453bdbdca93","metadata":{"reporter":"","stale_timestamp":"0001-01-01T00:00:00Z"},