### PR TITLE
When a host is not found we get a SEGV

### DIFF
--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -15,6 +15,11 @@ import (
 
 // Upload uploads a file with metadata to the url
 func Upload(url string, filename string, contentType string, metadata map[string]string) ([]byte, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("Error opening file %s %v", filename, err)
+	}
+	defer file.Close()
 	r, w := io.Pipe()
 	m := multipart.NewWriter(w)
 	go func() {
@@ -29,11 +34,9 @@ func Upload(url string, filename string, contentType string, metadata map[string
 
 		h.Set("Content-Type", overrideContentType(metadata))
 		part, err := m.CreatePart(h)
-		file, err := os.Open(filename)
 		if err != nil {
 			return
 		}
-		defer file.Close()
 		if _, err = io.Copy(part, file); err != nil {
 			return
 		}


### PR DESCRIPTION
The go routine doing a Copy was not getting interrupted
when a network error occurs. Moved the opening of the file outside
the go routine so we can close the file and cause the Copy to be
interrupted