### PR TITLE
Set GOARCH for Linux to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ debug:
 	dlv debug ${SRC_FILES}
 
 linux: 
-	GOOS=linux GOARCH=arm go build -x -o catalog_worker.linux ${SRC_FILES}
+	GOOS=linux GOARCH=amd64 go build -x -o catalog_worker.linux ${SRC_FILES}
 
 clean:
 	go clean


### PR DESCRIPTION
we might need other architectures for now added amd64 for our vms