### PR TITLE
Changed topological_inventory to catalog

### DIFF
--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -78,11 +78,11 @@ func Upload(url string, filename string, contentType string, metadata map[string
 // till we can get a more permanent solution to send metadata along
 // with multipart contents
 func overrideContentType(metadata map[string]string) string {
-	ct := "application/vnd.redhat.topological-inventory.filename+tgz"
+	ct := "application/vnd.redhat.catalog.filename+tgz"
 	if val, ok := metadata["task_url"]; ok {
 		parts := strings.Split(val, "/")
 		taskID := parts[len(parts)-1]
-		ct = fmt.Sprintf("application/vnd.redhat.topological-inventory.%s+tgz", taskID)
+		ct = fmt.Sprintf("application/vnd.redhat.catalog.%s+tgz", taskID)
 	}
 	return ct
 }


### PR DESCRIPTION
We were testing ingress with topological_inventory now with all
the changes in CI we can switch to catalog.
https://github.com/RedHatInsights/e2e-deploy/pull/2691