### PR TITLE
When logging we need the callers info

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -12,28 +13,28 @@ type Logger int
 const loggerID = "logger_id"
 
 func (l Logger) Printf(s string, args ...interface{}) {
-	log.Printf("[id=%d] %s", l, fmt.Sprintf(s, args...))
+	log.Printf("[%s] [id=%d] %s", callerInfo(), l, fmt.Sprintf(s, args...))
 }
 
 func (l Logger) Println(s string) {
-	log.Printf("[id=%d] %s", l, s)
+	log.Printf("[%s] [id=%d] %s", callerInfo(), l, s)
 }
 
 func (l Logger) Infof(s string, args ...interface{}) {
 	x := fmt.Sprintf(s, args...)
-	log.Infof("[id=%d] %s", l, x)
+	log.Infof("[%s] [id=%d] %s", callerInfo(), l, x)
 }
 
 func (l Logger) Info(s string) {
-	log.Infof("[id=%d] %s", l, s)
+	log.Infof("[%s] [id=%d] %s", callerInfo(), l, s)
 }
 
 func (l Logger) Errorf(s string, args ...interface{}) {
-	log.Errorf("[id=%d] %s", l, fmt.Sprintf(s, args...))
+	log.Errorf("[%s] [id=%d] %s", callerInfo(), l, fmt.Sprintf(s, args...))
 }
 
 func (l Logger) Error(s string) {
-	log.Errorf("[id=%d] %s", l, s)
+	log.Errorf("[%s] [id=%d] %s", callerInfo(), l, s)
 }
 
 func CtxWithLoggerID(ctx context.Context, id int) context.Context {
@@ -42,4 +43,12 @@ func CtxWithLoggerID(ctx context.Context, id int) context.Context {
 
 func GetLogger(ctx context.Context) Logger {
 	return Logger(ctx.Value(loggerID).(int))
+}
+
+func callerInfo() string {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "missing"
+	}
+	return fmt.Sprintf("%s:%d", file, line)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"strings"
+	"regexp"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -27,22 +27,28 @@ func TestGetLogger2(t *testing.T) {
 	logger.Println("One line")
 
 	logs := strBuf.String()
-	if !strings.Contains(logs, `level=info msg="[id=101] hello work!`) {
+	res, _ := regexp.MatchString(`level=info msg="\[\S*\] \[id=101] hello work!`, logs)
+	if !res {
 		t.Error("Failed with Info()")
 	}
-	if !strings.Contains(logs, `level=info msg="[id=101] flag is true`) {
+	res, _ = regexp.MatchString(`level=info msg="\[\S*\] \[id=101] flag is true`, logs)
+	if !res {
 		t.Error("Failed with Infof()")
 	}
-	if !strings.Contains(logs, `level=error msg="[id=101] unexpected happens`) {
+	res, _ = regexp.MatchString(`level=error msg="\[\S*\] \[id=101] unexpected happens`, logs)
+	if !res {
 		t.Error("Failed with Error()")
 	}
-	if !strings.Contains(logs, `level=error msg="[id=101] error bad input`) {
+	res, _ = regexp.MatchString(`level=error msg="\[\S*\] \[id=101] error bad input`, logs)
+	if !res {
 		t.Error("Failed with Errorf()")
 	}
-	if !strings.Contains(logs, `level=info msg="[id=101] This is number 100`) {
+	res, _ = regexp.MatchString(`level=info msg="\[\S*\] \[id=101] This is number 100`, logs)
+	if !res {
 		t.Error("Failed with Printf()")
 	}
-	if !strings.Contains(logs, `level=info msg="[id=101] One line`) {
+	res, _ = regexp.MatchString(`level=info msg="\[\S*\] \[id=101] One line`, logs)
+	if !res {
 		t.Error("Failed with Println()")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -119,6 +119,5 @@ func configLogger() *os.File {
 
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(logf)
-	log.SetReportCaller(true)
 	return logf
 }


### PR DESCRIPTION
Log the source code and the line number from where the caller is called
Remove the logrus.SetReportCaller(true) since that doesn't go deep
enough for us. We need to be one level down

Fixes #24

With the change  we get the line number of the caller
```
{"level":"info","msg":"[/Users/madhukanoor/devsrc/catalog_mqtt_client/internal/catalogtask/catalogtask.go:85] [id=2] Task Update Statue Code 204","time":"2021-01-31T21:39:57-05:00"}
{"level":"info","msg":"[/Users/madhukanoor/devsrc/catalog_mqtt_client/internal/catalogtask/catalogtask.go:86] [id=2] Response from Patch ","time":"2021-01-31T21:39:57-05:00"}
{"level":"info","msg":"[/Users/madhukanoor/devsrc/catalog_mqtt_client/internal/request/request.go:200] [id=2] Request finished","time":"2021-01-31T21:39:57-05:00"}
```