### PR TITLE
update status and return on error before goroutine startDispatcher

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -136,6 +136,12 @@ func processRequest(ctx context.Context,
 		return
 	}
 
+	err = task.Update(map[string]interface{}{"state": "running", "message": "Catalog Worker Started at " + time.Now().Format(time.RFC3339)})
+	if err != nil {
+		glog.Errorf("Error updating the task with the starting message, reason %v", err)
+		return
+	}
+
 	wc := towerapiworker.WorkChannels{}
 	wc.ErrorChannel = make(chan string)
 	wc.DispatchChannel = make(chan common.JobParam)
@@ -149,12 +155,6 @@ func processRequest(ctx context.Context,
 
 	wc.Shutdown = shutdown
 	go startDispatcher(ctx, config, wc, pw, wh)
-
-	err = task.Update(map[string]interface{}{"state": "running", "message": "Catalog Worker Started at " + time.Now().Format(time.RFC3339)})
-	if err != nil {
-		glog.Errorf("Error updating the task with the starting message")
-		return
-	}
 
 	for _, j := range req.Input.Jobs {
 		wc.DispatchChannel <- j


### PR DESCRIPTION
Return earlier on error to avoid starting the goroutine to run startDispatcher.

Fixes #31 