### PR TITLE
Rename RequestMessage to CatalogInventoryTask

### DIFF
--- a/internal/catalogtask/catalogtask.go
+++ b/internal/catalogtask/catalogtask.go
@@ -14,7 +14,7 @@ import (
 
 // CatalogTask is an interface that gets or updates a catalog task
 type CatalogTask interface {
-	Get() (*common.RequestMessage, error)
+	Get() (*common.CatalogInventoryTask, error)
 	Update(data map[string]interface{}) error
 }
 
@@ -31,14 +31,14 @@ func MakeCatalogTask(ctx context.Context, url string) CatalogTask {
 	return &defaultCatalogTask{ctx: ctx, url: url, glog: glog}
 }
 
-func (ct *defaultCatalogTask) Get() (*common.RequestMessage, error) {
+func (ct *defaultCatalogTask) Get() (*common.CatalogInventoryTask, error) {
 	body, err := getWorkPayload(ct.glog, ct.url)
 	if err != nil {
 		ct.glog.Errorf("Error reading payload in %s %v", ct.url, err)
 		return nil, err
 	}
 
-	req, err := parseRequest(ct.glog, body)
+	req, err := parseTask(ct.glog, body)
 	if err != nil {
 		ct.glog.Errorf("Error parsing payload in %s %v", ct.url, err)
 	}
@@ -125,9 +125,9 @@ func successGetCode(code int) bool {
 	return false
 }
 
-// Parse the request into RequestMessage
-func parseRequest(glog logger.Logger, b []byte) (*common.RequestMessage, error) {
-	req := common.RequestMessage{}
+// Parse the request into CatalogInventoryTask
+func parseTask(glog logger.Logger, b []byte) (*common.CatalogInventoryTask, error) {
+	req := common.CatalogInventoryTask{}
 	decoder := json.NewDecoder(bytes.NewReader(b))
 	decoder.UseNumber()
 	err := decoder.Decode(&req)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -32,8 +32,8 @@ type RequestInput struct {
 	Jobs           []JobParam `json:"jobs"`
 }
 
-// RequestMessage stores all attributes of a catalog task retrived from catalog-inventory API
-type RequestMessage struct {
+// CatalogInventoryTask stores all attributes of a task retrived from catalog-inventory API
+type CatalogInventoryTask struct {
 	Input     RequestInput `json:"input"`
 	CreatedAt time.Time    `json:"created_at"`
 	ID        string       `json:"id"`
@@ -43,6 +43,7 @@ type RequestMessage struct {
 }
 
 // MQTTMessage stores all attributes of the MQTTMessage sent by catalog-inventory API
+// TODO: remove when mqtt client is no longer needed
 type MQTTMessage struct {
 	URL string `json:"url"`
 }

--- a/internal/jsonwriter/jsonwriter_test.go
+++ b/internal/jsonwriter/jsonwriter_test.go
@@ -15,7 +15,7 @@ type mockCatalogTask struct {
 	mock.Mock
 }
 
-func (m *mockCatalogTask) Get() (*common.RequestMessage, error) { return nil, nil }
+func (m *mockCatalogTask) Get() (*common.CatalogInventoryTask, error) { return nil, nil }
 
 func (m *mockCatalogTask) Update(data map[string]interface{}) error {
 	m.Called(data)

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -112,7 +112,7 @@ func (factory *defaultPageWriterFactory) makePageWriter(ctx context.Context, for
 	return pw, err
 }
 
-// Process the incoming MQTT Work Request
+// Process the incoming Work Request
 // Fetch the Actual WorkPayload and start the work
 func processRequest(ctx context.Context,
 	url string, config *common.CatalogConfig,

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -27,8 +27,8 @@ func (fh *fakeHandler) StartWork(ctx context.Context, config *common.CatalogConf
 
 type fakeCatalogTask struct{}
 
-func (task *fakeCatalogTask) Get() (*common.RequestMessage, error) {
-	message := common.RequestMessage{
+func (task *fakeCatalogTask) Get() (*common.CatalogInventoryTask, error) {
+	message := common.CatalogInventoryTask{
 		ID:     "12345",
 		State:  "pending",
 		Status: "ok",

--- a/internal/tarwriter/tarwriter_test.go
+++ b/internal/tarwriter/tarwriter_test.go
@@ -19,7 +19,7 @@ type mockCatalogTask struct {
 	mock.Mock
 }
 
-func (m *mockCatalogTask) Get() (*common.RequestMessage, error) { return nil, nil }
+func (m *mockCatalogTask) Get() (*common.CatalogInventoryTask, error) { return nil, nil }
 
 func (m *mockCatalogTask) Update(data map[string]interface{}) error {
 	m.Called(data)


### PR DESCRIPTION
The original intention was to remove all wording with mqtt. There are not many remaining except the ones used by mqtt.go which we will keep for a while.

This intention is to rename struct `RequestMessage` to `CatalogInventoryTask` because the content comes from catalog inventory's Task table.