### PR TITLE
Add support for log level

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -5,7 +5,7 @@ import "time"
 // CatalogConfig stores the config parameters for the
 // Catalog Worker
 type CatalogConfig struct {
-	Debug                 bool   // Enable extra logging
+	Level                 string // The Log Level
 	URL                   string // The URL to your Ansible Tower
 	Token                 string // The Token used to authenticate with Ansible Tower
 	SkipVerifyCertificate bool   // Skip Certifcate Validation

--- a/internal/towerapiworker/test_scaffold.go
+++ b/internal/towerapiworker/test_scaffold.go
@@ -104,7 +104,7 @@ func (ts *testScaffold) base(t *testing.T, jp common.JobParam, responseCode int,
 	ts.terminateResponder = make(chan bool)
 	ts.terminateErrListener = make(chan bool)
 
-	ts.config = &common.CatalogConfig{Debug: false, URL: "https://192.1.1.1", Token: "123", SkipVerifyCertificate: true}
+	ts.config = &common.CatalogConfig{Level: "error", URL: "https://192.1.1.1", Token: "123", SkipVerifyCertificate: true}
 	ts.client = fakeClient(t, responseBody, responseCode)
 	ts.context = logger.CtxWithLoggerID(context.Background(), "123")
 }

--- a/main.go
+++ b/main.go
@@ -55,13 +55,14 @@ func makeConfig() *common.CatalogConfig {
 	config.Token = viper.GetString("ANSIBLE_TOWER.token")
 	config.URL = viper.GetString("ANSIBLE_TOWER.url")
 	config.SkipVerifyCertificate = !viper.GetBool("ANSIBLE_TOWER.verify_ssl")
-	config.Debug = viper.GetBool("logger.debug")
+	config.Level = viper.GetString("logger.level")
 	config.MQTTURL = viper.GetString("MQTT_BROKER.url")
 	config.GUID = viper.GetString("MQTT_BROKER.uuid")
 
 	flag.Parse()
-	if config.Debug {
-		log.SetLevel(log.DebugLevel)
+	level, err := log.ParseLevel(config.Level)
+	if err == nil {
+		log.SetLevel(level)
 	} else {
 		log.SetLevel(log.WarnLevel)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestMain(t *testing.T) {
 	os.Remove(info.Name())
 
 	assert.True(t, info.Size() > 0)
-	assert.True(t, frh.catalogConfig.Debug)
+	assert.Equal(t, "info", frh.catalogConfig.Level)
 	assert.Equal(t, "<<Your Tower URL>>", frh.catalogConfig.URL)
 	assert.Equal(t, "<<Your Tower Token>>", frh.catalogConfig.Token)
 	assert.Equal(t, &towerapiworker.DefaultAPIWorker{}, frh.workHandler)

--- a/testdata/catalog_sample.toml
+++ b/testdata/catalog_sample.toml
@@ -21,5 +21,5 @@ x_rh_identity="<<x-rh-identity>>" #dev only
 timeout_minutes=10
 
 [logger]
-debug=true
+level="info"
 logfile="./rhc-worker-catalog" #log file path and name without .log extension


### PR DESCRIPTION
This would make it in sync with the RHCD which uses the level
The valid values are
  fatal/error/warn/warning/info/debug/trace supported by logrus
The default value is
  warn if missing or an incorrect value is specified