### PR TITLE
Support for connection via Proxy Server

### DIFF
--- a/internal/common/httpclient.go
+++ b/internal/common/httpclient.go
@@ -39,7 +39,7 @@ func MakeHTTPClient(request *http.Request) (*http.Client, error) {
 		}
 
 		tlsConfig.BuildNameToCertificate()
-		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: http.ProxyFromEnvironment}
 		return &http.Client{Transport: transport}, nil
 	}
 

--- a/internal/towerapiworker/towerapiworker.go
+++ b/internal/towerapiworker/towerapiworker.go
@@ -124,7 +124,7 @@ func (w *workUnit) setClient(c *http.Client) error {
 		var tr *http.Transport
 		if w.config.SkipVerifyCertificate {
 			config := &tls.Config{InsecureSkipVerify: true}
-			tr = &http.Transport{TLSClientConfig: config}
+			tr = &http.Transport{TLSClientConfig: config, Proxy: http.ProxyFromEnvironment}
 		}
 		w.client = &http.Client{Transport: tr}
 	} else {

--- a/main.go
+++ b/main.go
@@ -115,18 +115,17 @@ func makeConfig() *common.CatalogConfig {
 
 //setProxies sets the HTTP and HTTPS PROXY env vars
 func setProxies() {
-	httpProxy := viper.GetString("PROXIES.HTTP_PROXY")
-	if httpProxy != "" {
+	if httpProxy := viper.GetString("PROXIES.HTTP_PROXY"); httpProxy != "" {
 		log.Infof("Setting HTTP_PROXY %s", httpProxy)
 		os.Setenv("HTTP_PROXY", httpProxy)
 	}
-	httpsProxy := viper.GetString("PROXIES.HTTPS_PROXY")
-	if httpsProxy != "" {
+
+	if httpsProxy := viper.GetString("PROXIES.HTTPS_PROXY"); httpsProxy != "" {
 		log.Infof("Setting HTTPS_PROXY %s", httpsProxy)
 		os.Setenv("HTTPS_PROXY", httpsProxy)
 	}
-	noProxy := viper.GetString("PROXIES.NO_PROXY")
-	if noProxy != "" {
+
+	if noProxy := viper.GetString("PROXIES.NO_PROXY"); noProxy != "" {
 		log.Infof("Setting NO_PROXY %s", noProxy)
 		os.Setenv("NO_PROXY", noProxy)
 	}

--- a/main.go
+++ b/main.go
@@ -109,7 +109,27 @@ func makeConfig() *common.CatalogConfig {
 		}
 	*/
 
+	setProxies()
 	return &config
+}
+
+//setProxies sets the HTTP and HTTPS PROXY env vars
+func setProxies() {
+	httpProxy := viper.GetString("PROXIES.HTTP_PROXY")
+	if httpProxy != "" {
+		log.Infof("Setting HTTP_PROXY %s", httpProxy)
+		os.Setenv("HTTP_PROXY", httpProxy)
+	}
+	httpsProxy := viper.GetString("PROXIES.HTTPS_PROXY")
+	if httpsProxy != "" {
+		log.Infof("Setting HTTPS_PROXY %s", httpsProxy)
+		os.Setenv("HTTPS_PROXY", httpsProxy)
+	}
+	noProxy := viper.GetString("PROXIES.NO_PROXY")
+	if noProxy != "" {
+		log.Infof("Setting NO_PROXY %s", noProxy)
+		os.Setenv("NO_PROXY", noProxy)
+	}
 }
 
 // Configure the logger

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,9 @@ func TestMain(t *testing.T) {
 	assert.Equal(t, "info", frh.catalogConfig.Level)
 	assert.Equal(t, "<<Your Tower URL>>", frh.catalogConfig.URL)
 	assert.Equal(t, "<<Your Tower Token>>", frh.catalogConfig.Token)
+	assert.Equal(t, os.Getenv("HTTP_PROXY"), "http://myproxy:3128")
+	assert.Equal(t, os.Getenv("HTTPS_PROXY"), "http://myproxy:3128")
+	assert.Equal(t, os.Getenv("NO_PROXY"), "localhost")
 	assert.Equal(t, &towerapiworker.DefaultAPIWorker{}, frh.workHandler)
 }
 

--- a/testdata/catalog_sample.toml
+++ b/testdata/catalog_sample.toml
@@ -23,3 +23,8 @@ timeout_minutes=10
 [logger]
 level="info"
 logfile="./rhc-worker-catalog" #log file path and name without .log extension
+
+[PROXIES]
+HTTP_PROXY="http://myproxy:3128"
+HTTPS_PROXY="http://myproxy:3128"
+NO_PROXY="localhost"


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2188

Supports the 3 environment variables HTTP_PROXY, HTTPS_PROXY & NO_PROXY.
These are standard variables used by Golang to support proxy navigation.
These environment variables can be set in the system for all processes.
But since the rhcd clears out all enviornment variables before it calls
a child process we can't have access to the environment variables set
at the service level. To solve that we are storing the proxy values in
our config file and then setting it in our process environment.
If and when rhcd is fixed to allow for propogation of environment
variables to child processes we can remove information from our
config files.